### PR TITLE
:sparkles: Add Social Rules to CoC

### DIFF
--- a/coc.html
+++ b/coc.html
@@ -146,16 +146,21 @@
 				inappropriate in a professional setting.
 			</li>
 		</ul>
-		<br/>
-		<p>In addition to these rules of conduct, everyone participating in events is encouraged to abide by the Recurse Center Social Rules:</p>
+		<br />
+		<p>In addition to these rules of conduct, everyone participating in events is encouraged to abide by the <a
+				target="_blank" rel="noreferrer" href="https://www.recurse.com/social-rules">Recurse Center's Social
+				Rules</a>:</p>
 		<ul>
 			<li>No well-actually's</li>
 			<li>No feigning surprise</li>
 			<li>No backseat driving</li>
 			<li>No subtle -isms</li>
 		</ul>
-		<p>The social rules name subtle behaviors that put other people down or show how much we know instead of supporting each other’s learning.
-		One thing that often surprises people about the social rules is that we expect people to break them from time to time. We’re all human, and we all make mistakes. The social rules are a guide to help us be better, not a list of things we’re not allowed to do.</p>
+		<p>The social rules name subtle behaviors that put other people down or show how much we know instead of
+			supporting each other’s learning.
+			One thing that often surprises people about the social rules is that we expect people to break them from
+			time to time. We’re all human, and we all make mistakes. The social rules are a guide to help us be better,
+			not a list of things we’re not allowed to do.</p>
 
 		<h2 id="enforcement-responsibilities">
 			Enforcement Responsibilities
@@ -267,7 +272,8 @@
 		</p>
 		<p>
 			Social Rules were sourced from
-			<a target="_blank" rel="noreferrer" href="https://www.recurse.com/social-rules">Recurse Center's Social Rules</a>.
+			<a target="_blank" rel="noreferrer" href="https://www.recurse.com/social-rules">Recurse Center's Social
+				Rules</a>.
 		</p>
 		<p>
 			For answers to common questions about this code of conduct, see

--- a/coc.html
+++ b/coc.html
@@ -65,24 +65,6 @@
 	<h1>OTC's Code of Conduct</h1>
 
 	<main id="main-content">
-		<h2 id="introduction">Introduction</h2>
-		<p>
-			<a href="https://ourtech.community">Our Tech Community</a>'s
-			Code of Conduct is based on:
-		<ul>
-			<li><a target="_blank" rel="noreferrer"
-					href="https://www.contributor-covenant.org/version/2/1/code_of_conduct">Contributor Covenant
-					(v2.1)</a>
-				and has been modified as allowed by the
-				<a target="_blank" rel="noreferrer" href="https://choosealicense.com/licenses/cc-by-4.0">CC-BY-4.0</a>
-				license.
-			</li>
-			<li>
-				<a target="_blank" rel="noreferrer" href="https://www.recurse.com/social-rules">Recurse Center's Social
-					Rules</a>.
-			</li>
-		</ul>
-		</p>
 
 		<h2 id="our-pledge">Our Pledge</h2>
 		<p>

--- a/coc.html
+++ b/coc.html
@@ -1,327 +1,288 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta
-			name="keywords"
-			content="OTC, Our Tech Community, OTC CatchUp, Technical community"
-		/>
-		<meta name="description" content="OTC's Code of Conduct." />
-		<meta name="author" content="Harsh Kapadia" />
-		<meta property="og:site_name" content="Our Tech Community" />
-		<meta property="og:title" content="Code of Conduct" />
-		<meta property="og:type" content="website" />
-		<meta property="og:description" content="OTC's Code of Conduct." />
-		<meta property="og:url" content="https://ourtech.community/coc" />
-		<meta
-			property="og:image"
-			content="https://ourtech.community/static/img/og-img/coc.png"
-		/>
-		<meta property="og:image:width" content="1200" />
-		<meta property="og:image:height" content="600" />
-		<meta property="twitter:card" content="summary_large_image" />
-		<meta
-			property="twitter:image"
-			content="https://ourtech.community/static/img/og-img/coc.png"
-		/>
 
-		<script defer src="static/js/script.js"></script>
+<head>
+	<meta charset="UTF-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<meta name="keywords" content="OTC, Our Tech Community, OTC CatchUp, Technical community" />
+	<meta name="description" content="OTC's Code of Conduct." />
+	<meta name="author" content="Harsh Kapadia" />
+	<meta property="og:site_name" content="Our Tech Community" />
+	<meta property="og:title" content="Code of Conduct" />
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="OTC's Code of Conduct." />
+	<meta property="og:url" content="https://ourtech.community/coc" />
+	<meta property="og:image" content="https://ourtech.community/static/img/og-img/coc.png" />
+	<meta property="og:image:width" content="1200" />
+	<meta property="og:image:height" content="600" />
+	<meta property="twitter:card" content="summary_large_image" />
+	<meta property="twitter:image" content="https://ourtech.community/static/img/og-img/coc.png" />
 
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Poppins&display=swap"
-			rel="stylesheet"
-		/>
+	<script defer src="static/js/script.js"></script>
 
-		<link rel="stylesheet" href="/static/css/style.css" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet" />
 
-		<link
-			rel="shortcut icon"
-			href="static/img/favicon.ico"
-			type="image/x-icon"
-		/>
+	<link rel="stylesheet" href="/static/css/style.css" />
 
-		<title>OTC's Code of Conduct</title>
-	</head>
+	<link rel="shortcut icon" href="static/img/favicon.ico" type="image/x-icon" />
 
-	<body>
-		<header>
-			<nav>
-				<div class="burger-menu">
-					<div class="line-1"></div>
-					<div class="line-2"></div>
-					<div class="line-3"></div>
-				</div>
+	<title>OTC's Code of Conduct</title>
+</head>
 
-				<ul class="navbar-ul hide-burger-menu burger-menu-dropdown">
-					<li><a href="/">Home</a></li>
-					<li>
-						<a
-							href="https://events.ourtech.community"
-							target="_blank"
-							rel="noreferrer"
-							>Our Events</a
-						>
-					</li>
-					<li>
-						<a
-							href="https://catchup.ourtech.community"
-							target="_blank"
-							rel="noreferrer"
-							>OTC CatchUp</a
-						>
-					</li>
-					<li>
-						<a
-							href="https://meetup.ourtech.community"
-							target="_blank"
-							rel="noreferrer"
-							>OTC MeetUp</a
-						>
-					</li>
-					<li><a href="two-years">Two Years of OTC</a></li>
-					<li><a href="team">Our Team</a></li>
-					<li><a href="coc">Code of Conduct</a></li>
-					<li>
-						<a
-							href="https://links.ourtech.community"
-							target="_blank"
-							rel="noreferrer"
-							>All Links</a
-						>
-					</li>
-				</ul>
-			</nav>
-		</header>
+<body>
+	<header>
+		<nav>
+			<div class="burger-menu">
+				<div class="line-1"></div>
+				<div class="line-2"></div>
+				<div class="line-3"></div>
+			</div>
 
-		<h1>OTC's Code of Conduct</h1>
+			<ul class="navbar-ul hide-burger-menu burger-menu-dropdown">
+				<li><a href="/">Home</a></li>
+				<li>
+					<a href="https://events.ourtech.community" target="_blank" rel="noreferrer">Our Events</a>
+				</li>
+				<li>
+					<a href="https://catchup.ourtech.community" target="_blank" rel="noreferrer">OTC CatchUp</a>
+				</li>
+				<li>
+					<a href="https://meetup.ourtech.community" target="_blank" rel="noreferrer">OTC MeetUp</a>
+				</li>
+				<li><a href="two-years">Two Years of OTC</a></li>
+				<li><a href="team">Our Team</a></li>
+				<li><a href="coc">Code of Conduct</a></li>
+				<li>
+					<a href="https://links.ourtech.community" target="_blank" rel="noreferrer">All Links</a>
+				</li>
+			</ul>
+		</nav>
+	</header>
 
-		<main id="main-content">
-			<h2 id="introduction">Introduction</h2>
-			<p>
-				<a href="https://ourtech.community">Our Tech Community</a>'s
-				Code of Conduct is based on the
-				<a
-					target="_blank"
-					rel="noreferrer"
-					href="https://www.contributor-covenant.org/version/2/1/code_of_conduct"
-					>Contributor Covenant (v2.1)</a
-				>
+	<h1>OTC's Code of Conduct</h1>
+
+	<main id="main-content">
+		<h2 id="introduction">Introduction</h2>
+		<p>
+			<a href="https://ourtech.community">Our Tech Community</a>'s
+			Code of Conduct is based on:
+		<ul>
+			<li><a target="_blank" rel="noreferrer"
+					href="https://www.contributor-covenant.org/version/2/1/code_of_conduct">Contributor Covenant
+					(v2.1)</a>
 				and has been modified as allowed by the
-				<a
-					target="_blank"
-					rel="noreferrer"
-					href="https://choosealicense.com/licenses/cc-by-4.0"
-					>CC-BY-4.0</a
-				>
+				<a target="_blank" rel="noreferrer" href="https://choosealicense.com/licenses/cc-by-4.0">CC-BY-4.0</a>
 				license.
-			</p>
+			</li>
+			<li>
+				<a target="_blank" rel="noreferrer" href="https://www.recurse.com/social-rules">Recurse Center's Social
+					Rules</a>.
+			</li>
+		</ul>
+		</p>
 
-			<h2 id="our-pledge">Our Pledge</h2>
-			<p>
-				We as members, contributors, and leaders pledge to make
-				participation in our community a harassment-free experience for
-				everyone, regardless of age, body size, visible or invisible
-				disability, ethnicity, sex characteristics, gender identity and
-				expression, level of experience, education, socio-economic
-				status, nationality, personal appearance, race, caste, color,
-				religion, or sexual identity and orientation.
-			</p>
-			<p>
-				We pledge to act and interact in ways that contribute to an
-				open, welcoming, diverse, inclusive, and healthy community.
-			</p>
+		<h2 id="our-pledge">Our Pledge</h2>
+		<p>
+			We as members, contributors, and leaders pledge to make
+			participation in our community a harassment-free experience for
+			everyone, regardless of age, body size, visible or invisible
+			disability, ethnicity, sex characteristics, gender identity and
+			expression, level of experience, education, socio-economic
+			status, nationality, personal appearance, race, caste, color,
+			religion, or sexual identity and orientation.
+		</p>
+		<p>
+			We pledge to act and interact in ways that contribute to an
+			open, welcoming, diverse, inclusive, and healthy community.
+		</p>
 
-			<h2 id="our-standards">Our Standards</h2>
-			<p>Examples of <strong>acceptable behavior</strong> include:</p>
-			<ul>
-				<li>Demonstrating empathy and kindness toward other people.</li>
-				<li>Accommodating for people with disabilities.</li>
-				<li>Abide by the rules of the community and event.</li>
-				<li>
-					Being respectful of differing opinions, viewpoints and
-					experiences.
-				</li>
-				<li>Giving and gracefully accepting constructive feedback.</li>
-				<li>
-					Accepting responsibility and apologizing to those affected
-					by our mistakes and learning from the experience.
-				</li>
-				<li>
-					Focusing on what is best not just for us as individuals, but
-					for the overall community.
-				</li>
-			</ul>
-			<p>Examples of <strong>unacceptable behavior</strong> include:</p>
-			<ul>
-				<li>Not co-operating with the organising team.</li>
-				<li>
-					The use of sexualized language or imagery, and sexual
-					attention or advances of any kind.
-				</li>
-				<li>Repeatedly flouting event rules.</li>
-				<li>
-					The use of derogatory or discriminatory words, sentiments or
-					statements against any race, gender, sexuality and/or
-					religion.
-				</li>
-				<li>
-					Trolling, insulting or derogatory comments, and personal or
-					political attacks.
-				</li>
-				<li>Public or private harassment.</li>
-				<li>
-					Publishing others’ private information, such as a physical
-					or email address, without their explicit permission.
-				</li>
-				<li>
-					Other conduct which could reasonably be considered
-					inappropriate in a professional setting.
-				</li>
-			</ul>
+		<h2 id="our-standards">Our Standards</h2>
+		<p>Examples of <strong>acceptable behavior</strong> include:</p>
+		<ul>
+			<li>Demonstrating empathy and kindness toward other people.</li>
+			<li>Accommodating for people with disabilities.</li>
+			<li>Abide by the rules of the community and event.</li>
+			<li>
+				Being respectful of differing opinions, viewpoints and
+				experiences.
+			</li>
+			<li>Giving and gracefully accepting constructive feedback.</li>
+			<li>
+				Accepting responsibility and apologizing to those affected
+				by our mistakes and learning from the experience.
+			</li>
+			<li>
+				Focusing on what is best not just for us as individuals, but
+				for the overall community.
+			</li>
+		</ul>
+		<p>Examples of <strong>unacceptable behavior</strong> include:</p>
+		<ul>
+			<li>Not co-operating with the organising team.</li>
+			<li>
+				The use of sexualized language or imagery, and sexual
+				attention or advances of any kind.
+			</li>
+			<li>Repeatedly flouting event rules.</li>
+			<li>
+				The use of derogatory or discriminatory words, sentiments or
+				statements against any race, gender, sexuality and/or
+				religion.
+			</li>
+			<li>
+				Trolling, insulting or derogatory comments, and personal or
+				political attacks.
+			</li>
+			<li>Public or private harassment.</li>
+			<li>
+				Publishing others’ private information, such as a physical
+				or email address, without their explicit permission.
+			</li>
+			<li>
+				Other conduct which could reasonably be considered
+				inappropriate in a professional setting.
+			</li>
+		</ul>
+		<br/>
+		<p>In addition to these rules of conduct, everyone participating in events is encouraged to abide by the Recurse Center Social Rules:</p>
+		<ul>
+			<li>No well-actually's</li>
+			<li>No feigning surprise</li>
+			<li>No backseat driving</li>
+			<li>No subtle -isms</li>
+		</ul>
+		<p>The social rules name subtle behaviors that put other people down or show how much we know instead of supporting each other’s learning.
+		One thing that often surprises people about the social rules is that we expect people to break them from time to time. We’re all human, and we all make mistakes. The social rules are a guide to help us be better, not a list of things we’re not allowed to do.</p>
 
-			<h2 id="enforcement-responsibilities">
-				Enforcement Responsibilities
-			</h2>
-			<p>
-				Community leaders are responsible for clarifying and enforcing
-				our standards of acceptable behavior and will take appropriate
-				and fair corrective action in response to any behavior that they
-				deem inappropriate, threatening, offensive, or harmful.
-			</p>
-			<p>
-				Community leaders have the right and responsibility to remove,
-				edit, or reject comments, commits, code, wiki edits, issues, and
-				other contributions that are not aligned to this Code of
-				Conduct, and will communicate reasons for moderation decisions
-				when appropriate.
-			</p>
-			<h2 id="scope">Scope</h2>
-			<p>
-				This Code of Conduct applies within all community spaces and
-				also applies when an individual is officially representing the
-				community in public spaces. Examples of representing our
-				community include using an official e-mail address, posting via
-				an official social media account, or acting as an appointed
-				representative at an online or offline event.
-			</p>
+		<h2 id="enforcement-responsibilities">
+			Enforcement Responsibilities
+		</h2>
+		<p>
+			Community leaders are responsible for clarifying and enforcing
+			our standards of acceptable behavior and will take appropriate
+			and fair corrective action in response to any behavior that they
+			deem inappropriate, threatening, offensive, or harmful.
+		</p>
+		<p>
+			Community leaders have the right and responsibility to remove,
+			edit, or reject comments, commits, code, wiki edits, issues, and
+			other contributions that are not aligned to this Code of
+			Conduct, and will communicate reasons for moderation decisions
+			when appropriate.
+		</p>
+		<h2 id="scope">Scope</h2>
+		<p>
+			This Code of Conduct applies within all community spaces and
+			also applies when an individual is officially representing the
+			community in public spaces. Examples of representing our
+			community include using an official e-mail address, posting via
+			an official social media account, or acting as an appointed
+			representative at an online or offline event.
+		</p>
 
-			<h2 id="enforcement">Enforcement</h2>
-			<p>
-				Instances of abusive, harassing, or otherwise unacceptable
-				behavior may be reported to the community leaders responsible
-				for enforcement at
-				<a href="mailto:contact@ourtech.community"
-					>contact@ourtech.community</a
-				>. All complaints will be reviewed and investigated promptly and
-				fairly.
-			</p>
-			<p>
-				All community leaders are obligated to respect the privacy and
-				security of the reporter of any incident.
-			</p>
+		<h2 id="enforcement">Enforcement</h2>
+		<p>
+			Instances of abusive, harassing, or otherwise unacceptable
+			behavior may be reported to the community leaders responsible
+			for enforcement at
+			<a href="mailto:contact@ourtech.community">contact@ourtech.community</a>. All complaints will be reviewed
+			and investigated promptly and
+			fairly.
+		</p>
+		<p>
+			All community leaders are obligated to respect the privacy and
+			security of the reporter of any incident.
+		</p>
 
-			<h2 id="enforcement-guidelines">Enforcement Guidelines</h2>
-			<p>
-				Community leaders will follow these Community Impact Guidelines
-				in determining the consequences for any action they deem in
-				violation of this Code of Conduct:
-			</p>
-			<h3 id="1-correction">1. Correction</h3>
-			<p>
-				<strong>Community Impact</strong>: Use of inappropriate language
-				or other behavior deemed unprofessional or unwelcome in the
-				community.
-			</p>
-			<p>
-				<strong>Consequence</strong>: A private, written warning from
-				community leaders, providing clarity around the nature of the
-				violation and an explanation of why the behavior was
-				inappropriate. A public apology may be requested.
-			</p>
-			<h3 id="2-warning">2. Warning</h3>
-			<p>
-				<strong>Community Impact</strong>: A violation through a single
-				incident or series of actions.
-			</p>
-			<p>
-				<strong>Consequence</strong>: A warning with consequences for
-				continued behavior. No interaction with the people involved,
-				including unsolicited interaction with those enforcing the Code
-				of Conduct, for a specified period of time. This includes
-				avoiding interactions in community spaces as well as external
-				channels like social media. Violating these terms may lead to a
-				temporary or permanent ban.
-			</p>
-			<h3 id="3-temporary-ban">3. Temporary Ban</h3>
-			<p>
-				<strong>Community Impact</strong>: A serious violation of
-				community standards, including sustained inappropriate behavior.
-			</p>
-			<p>
-				<strong>Consequence</strong>: A temporary ban from any sort of
-				interaction or public communication with the community for a
-				specified period of time. No public or private interaction with
-				the people involved, including unsolicited interaction with
-				those enforcing the Code of Conduct, is allowed during this
-				period. Violating these terms may lead to a permanent ban.
-			</p>
-			<h3 id="4-permanent-ban">4. Permanent Ban</h3>
-			<p>
-				<strong>Community Impact</strong>: Demonstrating a pattern of
-				violation of community standards, including sustained
-				inappropriate behavior, harassment of an individual, or
-				aggression toward or disparagement of classes of individuals.
-			</p>
-			<p>
-				<strong>Consequence</strong>: A permanent ban from any sort of
-				public interaction within the community.
-			</p>
+		<h2 id="enforcement-guidelines">Enforcement Guidelines</h2>
+		<p>
+			Community leaders will follow these Community Impact Guidelines
+			in determining the consequences for any action they deem in
+			violation of this Code of Conduct:
+		</p>
+		<h3 id="1-correction">1. Correction</h3>
+		<p>
+			<strong>Community Impact</strong>: Use of inappropriate language
+			or other behavior deemed unprofessional or unwelcome in the
+			community.
+		</p>
+		<p>
+			<strong>Consequence</strong>: A private, written warning from
+			community leaders, providing clarity around the nature of the
+			violation and an explanation of why the behavior was
+			inappropriate. A public apology may be requested.
+		</p>
+		<h3 id="2-warning">2. Warning</h3>
+		<p>
+			<strong>Community Impact</strong>: A violation through a single
+			incident or series of actions.
+		</p>
+		<p>
+			<strong>Consequence</strong>: A warning with consequences for
+			continued behavior. No interaction with the people involved,
+			including unsolicited interaction with those enforcing the Code
+			of Conduct, for a specified period of time. This includes
+			avoiding interactions in community spaces as well as external
+			channels like social media. Violating these terms may lead to a
+			temporary or permanent ban.
+		</p>
+		<h3 id="3-temporary-ban">3. Temporary Ban</h3>
+		<p>
+			<strong>Community Impact</strong>: A serious violation of
+			community standards, including sustained inappropriate behavior.
+		</p>
+		<p>
+			<strong>Consequence</strong>: A temporary ban from any sort of
+			interaction or public communication with the community for a
+			specified period of time. No public or private interaction with
+			the people involved, including unsolicited interaction with
+			those enforcing the Code of Conduct, is allowed during this
+			period. Violating these terms may lead to a permanent ban.
+		</p>
+		<h3 id="4-permanent-ban">4. Permanent Ban</h3>
+		<p>
+			<strong>Community Impact</strong>: Demonstrating a pattern of
+			violation of community standards, including sustained
+			inappropriate behavior, harassment of an individual, or
+			aggression toward or disparagement of classes of individuals.
+		</p>
+		<p>
+			<strong>Consequence</strong>: A permanent ban from any sort of
+			public interaction within the community.
+		</p>
 
-			<h2 id="attribution">Attribution</h2>
-			<p>
-				This Code of Conduct is adapted from the
-				<a
-					target="_blank"
-					rel="noreferrer"
-					href="https://www.contributor-covenant.org/version/2/1/code_of_conduct"
-					>Contributor Covenant (v2.1)</a
-				>.
-			</p>
-			<p>
-				Community Impact Guidelines were inspired by
-				<a
-					target="_blank"
-					rel="noreferrer"
-					href="https://github.com/mozilla/diversity"
-					>Mozilla’s code of conduct enforcement ladder</a
-				>.
-			</p>
-			<p>
-				For answers to common questions about this code of conduct, see
-				the
-				<a
-					target="_blank"
-					rel="noreferrer"
-					href="https://www.contributor-covenant.org/faq"
-					>FAQ</a
-				>.
-			</p>
-			<p>
-				<a
-					target="_blank"
-					rel="noreferrer"
-					href="https://www.contributor-covenant.org/translations"
-					>Translations are available</a
-				>.
-			</p>
-		</main>
+		<h2 id="attribution">Attribution</h2>
+		<p>
+			This Code of Conduct is adapted from the
+			<a target="_blank" rel="noreferrer"
+				href="https://www.contributor-covenant.org/version/2/1/code_of_conduct">Contributor Covenant (v2.1)</a>.
+		</p>
+		<p>
+			Community Impact Guidelines were inspired by
+			<a target="_blank" rel="noreferrer" href="https://github.com/mozilla/diversity">Mozilla’s code of conduct
+				enforcement ladder</a>.
+		</p>
+		<p>
+			Social Rules were sourced from
+			<a target="_blank" rel="noreferrer" href="https://www.recurse.com/social-rules">Recurse Center's Social Rules</a>.
+		</p>
+		<p>
+			For answers to common questions about this code of conduct, see
+			the
+			<a target="_blank" rel="noreferrer" href="https://www.contributor-covenant.org/faq">FAQ</a>.
+		</p>
+		<p>
+			<a target="_blank" rel="noreferrer" href="https://www.contributor-covenant.org/translations">Translations
+				are available</a>.
+		</p>
+	</main>
 
-		<footer>
-			<a href="/">Our Tech Community</a>
-		</footer>
-	</body>
+	<footer>
+		<a href="/">Our Tech Community</a>
+	</footer>
+</body>
+
 </html>


### PR DESCRIPTION
Closes #7.
(post-review) edit: Closes #11.

Adding social rules => Updating the Introduction and Attribution sections (a redundancy noted in #11), and actually adding the rules to the "Our Standards" section.

Two points to be noted:

1. My formatter went haywire, resulting in many changed lines. The contributing guidelines don't make it clear whether this is okay (see #10). If necessary, I can amend the commit to undo this.

2. I had to choose between adding a concise version of the rules (like in https://kentcdodds.com/conduct), or the explanations as well (like in https://www.recurse.com/social-rules). For the moment, I've chosen to go with the former approach. As I see it, there are a few ways to do this:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; a. Leave it as it is in the commit.
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; b. Add a line linking back to https://www.recurse.com/social-rules for further explanation.
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; c. Separate the social rules into another page entirely, seeing as they're not rules set in stone in the Code of Conduct.
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; d. Include the entire explanation of all four rules on the CoC page.

I don't recommend the last option, seeing as the page is already text-heavy. Regardless, I'll amend the commit based on reviews and suggestions.
